### PR TITLE
Add support for query suggestions (aka "did you mean")

### DIFF
--- a/src/Query/Suggestion.php
+++ b/src/Query/Suggestion.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\Discoverer\Query;
+
+use SilverStripe\Core\Injector\Injectable;
+
+class Suggestion
+{
+
+    use Injectable;
+
+    public function __construct(private string $queryString, private ?int $limit = null, private array $fields = [])
+    {
+    }
+
+    public function getQueryString(): string
+    {
+        return $this->queryString;
+    }
+
+    public function setQueryString(string $queryString): void
+    {
+        $this->queryString = $queryString;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(?int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function addField(string $fieldName): self
+    {
+        $this->fields[] = $fieldName;
+
+        return $this;
+    }
+
+}

--- a/src/Query/Suggestion.php
+++ b/src/Query/Suggestion.php
@@ -40,6 +40,13 @@ class Suggestion
         return $this->fields;
     }
 
+    public function setFields(array $fields): self
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
     public function addField(string $fieldName): self
     {
         $this->fields[] = $fieldName;

--- a/src/Service/Results/Suggestions.php
+++ b/src/Service/Results/Suggestions.php
@@ -71,7 +71,7 @@ class Suggestions extends ViewableData
         return $this;
     }
 
-    public function addSuggestion(string $suggestions): static
+    public function addSuggestion(string $suggestions): self
     {
         $this->suggestions[] = $suggestions;
 

--- a/src/Service/Results/Suggestions.php
+++ b/src/Service/Results/Suggestions.php
@@ -9,7 +9,7 @@ use SilverStripe\View\ViewableData;
 use Traversable;
 
 /**
- * $desired* fields:
+ * $targetQueryStringField and $targetQueryUrl fields:
  *
  * Search suggestions are often used as links back to a search form. In order to do that, you need to know where the
  * form is localed (a page URL in many cases) and what field is used for holding the search query string. These fields
@@ -22,9 +22,9 @@ use Traversable;
 class Suggestions extends ViewableData
 {
 
-    private string $desiredQueryStringField = '';
+    private string $targetQueryStringField = '';
 
-    private string $desiredLinkUrl = '';
+    private string $targetQueryUrl = '';
 
     private bool $success = false;
 
@@ -35,26 +35,26 @@ class Suggestions extends ViewableData
         return $this->renderWith(static::class);
     }
 
-    public function getDesiredQueryStringField(): string
+    public function getTargetQueryStringField(): string
     {
-        return $this->desiredQueryStringField;
+        return $this->targetQueryStringField;
     }
 
-    public function setDesiredQueryStringField(string $desiredQueryStringField): self
+    public function setTargetQueryStringField(string $targetQueryStringField): self
     {
-        $this->desiredQueryStringField = $desiredQueryStringField;
+        $this->targetQueryStringField = $targetQueryStringField;
 
         return $this;
     }
 
-    public function getDesiredLinkUrl(): string
+    public function getTargetQueryUrl(): string
     {
-        return $this->desiredLinkUrl;
+        return $this->targetQueryUrl;
     }
 
-    public function setDesiredLinkUrl(string $desiredLinkUrl): self
+    public function setTargetQueryUrl(string $targetQueryUrl): self
     {
-        $this->desiredLinkUrl = $desiredLinkUrl;
+        $this->targetQueryUrl = $targetQueryUrl;
 
         return $this;
     }

--- a/src/Service/Results/Suggestions.php
+++ b/src/Service/Results/Suggestions.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SilverStripe\Discoverer\Service\Results;
+
+use ArrayIterator;
+use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\ORM\FieldType\DBText;
+use SilverStripe\View\ViewableData;
+use Traversable;
+
+/**
+ * $desired* fields:
+ *
+ * Search suggestions are often used as links back to a search form. In order to do that, you need to know where the
+ * form is localed (a page URL in many cases) and what field is used for holding the search query string. These fields
+ * are not automatically populated, but you can populate them if you would like to keep that information localised to
+ * the Suggestions object, so that it might be easier for you to access them in your template (or wherever you need
+ * them)
+ *
+ * See also: Suggestions.ss for an example of how these fields are implemented to create links back to a search form
+ */
+class Suggestions extends ViewableData
+{
+
+    private string $desiredQueryStringField = '';
+
+    private string $desiredLinkUrl = '';
+
+    private bool $success = false;
+
+    private array $suggestions = [];
+
+    public function forTemplate(): DBHTMLText
+    {
+        return $this->renderWith(static::class);
+    }
+
+    public function getDesiredQueryStringField(): string
+    {
+        return $this->desiredQueryStringField;
+    }
+
+    public function setDesiredQueryStringField(string $desiredQueryStringField): self
+    {
+        $this->desiredQueryStringField = $desiredQueryStringField;
+
+        return $this;
+    }
+
+    public function getDesiredLinkUrl(): string
+    {
+        return $this->desiredLinkUrl;
+    }
+
+    public function setDesiredLinkUrl(string $desiredLinkUrl): self
+    {
+        $this->desiredLinkUrl = $desiredLinkUrl;
+
+        return $this;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public function setSuccess(bool $success): self
+    {
+        $this->success = $success;
+
+        return $this;
+    }
+
+    public function addSuggestion(string $suggestions): static
+    {
+        $this->suggestions[] = $suggestions;
+
+        return $this;
+    }
+
+    public function getSuggestions(): array
+    {
+        return $this->suggestions;
+    }
+
+    public function getIterator(): Traversable
+    {
+        if (!$this->suggestions) {
+            return new ArrayIterator();
+        }
+
+        return new ArrayIterator($this->convertArrayForTemplate());
+    }
+
+    /**
+     * Silverstripe 5.3 will have native support for looping primitives in templates:
+     * https://github.com/silverstripe/silverstripe-framework/issues/11196
+     *
+     * We need to support versions of Silverstripe below 5.3 though, so we need this polyfill. It emulates the
+     * template implementation method from Silverstripe 5.3, so we should be able to remove this later without
+     * negatively impacting any project's template implementation
+     */
+    private function convertArrayForTemplate(): array
+    {
+        $arrayList = [];
+
+        foreach ($this->suggestions as $suggestion) {
+            $text = DBText::create('suggestion');
+            $text->setValue($suggestion);
+
+            $arrayList[] = $text;
+        }
+
+        return $arrayList;
+    }
+
+}

--- a/src/Service/SearchService.php
+++ b/src/Service/SearchService.php
@@ -5,7 +5,9 @@ namespace SilverStripe\Discoverer\Service;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Analytics\AnalyticsData;
 use SilverStripe\Discoverer\Query\Query;
+use SilverStripe\Discoverer\Query\Suggestion;
 use SilverStripe\Discoverer\Service\Results\Results;
+use SilverStripe\Discoverer\Service\Results\Suggestions;
 
 class SearchService
 {
@@ -26,6 +28,11 @@ class SearchService
     public function search(Query $query, string $indexName): Results
     {
         return $this->adaptor->search($query, $indexName);
+    }
+
+    public function querySuggestion(Suggestion $suggestion, string $indexName): Suggestions
+    {
+        return $this->adaptor->querySuggestion($suggestion, $indexName);
     }
 
     public function processAnalytics(AnalyticsData $analyticsData): void

--- a/src/Service/SearchServiceAdaptor.php
+++ b/src/Service/SearchServiceAdaptor.php
@@ -4,12 +4,16 @@ namespace SilverStripe\Discoverer\Service;
 
 use SilverStripe\Discoverer\Analytics\AnalyticsData;
 use SilverStripe\Discoverer\Query\Query;
+use SilverStripe\Discoverer\Query\Suggestion;
 use SilverStripe\Discoverer\Service\Results\Results;
+use SilverStripe\Discoverer\Service\Results\Suggestions;
 
 interface SearchServiceAdaptor
 {
 
     public function search(Query $query, string $indexName): Results;
+
+    public function querySuggestion(Suggestion $suggestion, string $indexName): Suggestions;
 
     public function processAnalytics(AnalyticsData $analyticsData): void;
 

--- a/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
+++ b/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
@@ -1,0 +1,9 @@
+<ul>
+    <% loop $Me %>
+        <% if $Up.DesiredUrl && $Up.DesiredQueryField %>
+            <li><a href="{$Up.DesiredUrl}?{$Up.DesiredQueryField}={$Me}">$Me</a></li>
+        <% else %>
+            <li>$Me</li>
+        <% end_if %>
+    <% end_loop %>
+</ul>

--- a/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
+++ b/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
@@ -1,7 +1,7 @@
 <ul>
     <% loop $Me %>
-        <% if $Up.DesiredUrl && $Up.DesiredQueryField %>
-            <li><a href="{$Up.DesiredUrl}?{$Up.DesiredQueryField}={$Me}">$Me</a></li>
+        <% if $Up.TargetQueryUrl && $Up.TargetQueryStringField %>
+            <li><a href="{$Up.TargetQueryUrl}?{$Up.TargetQueryStringField}={$Me}">$Me</a></li>
         <% else %>
             <li>$Me</li>
         <% end_if %>

--- a/tests/Query/SuggestionTest.php
+++ b/tests/Query/SuggestionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\Discoverer\Tests\Query;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Discoverer\Query\Suggestion;
+
+class SuggestionTest extends SapphireTest
+{
+
+    public function testQueryString(): void
+    {
+        $suggestion = Suggestion::create('initial query string');
+
+        $this->assertEquals('initial query string', $suggestion->getQueryString());
+
+        $suggestion->setQueryString('modified query string');
+
+        $this->assertEquals('modified query string', $suggestion->getQueryString());
+    }
+
+    public function testSetLimit(): void
+    {
+        $suggestion = Suggestion::create('initial query string', 10);
+
+        $this->assertEquals(10, $suggestion->getLimit());
+
+        $suggestion->setLimit(20);
+
+        $this->assertEquals(20, $suggestion->getLimit());
+    }
+
+    public function testAddSetFields(): void
+    {
+        $suggestion = Suggestion::create('initial query string', null, ['test1']);
+
+        $this->assertEquals(['test1'], $suggestion->getFields());
+
+        $suggestion->addField('test2');
+
+        $this->assertEquals(['test1', 'test2'], $suggestion->getFields());
+
+        $suggestion->setFields(['test3']);
+
+        $this->assertEquals(['test3'], $suggestion->getFields());
+    }
+
+}


### PR DESCRIPTION
## Query

New `Suggestion` class (name is singular) provides the following options:

1. Required: Query string that you want suggestions for
2. Optional: Limit the number of suggestions that are returned
3. Optional: Field that should be used for generating suggestions

Noting that not all services support "fields" for their suggestions, but this feels like a reasonable feature that could be silenctly ignored if plugins are created for those services.

## Result

New `Suggestions` class (name is plural) which contains an array of string suggestions that were returned from your desired service.

`forTemplate()` and `getIterator()` provided so that you can loop through this object, which will give you one suggestion per iteration.

A couple of helper properties were added:

* `$desiredQueryStringField`
* `$desiredLinkUrl`

I've added a description of these fields to the class docblock, but TL;DR: they are there for developers to populate (if they want) so that when this object attempt to render, it knows where to link the query suggestion off to (EG: your search page).