### PR TITLE
Provide a FieldService to help with field name conversions

### DIFF
--- a/docs/field-convensions.md
+++ b/docs/field-convensions.md
@@ -3,8 +3,17 @@
 Different search services use different naming convensions for fields, but most like to use either kebab-case or
 snake_case.
 
-In order to provide a consistent pattern for interacting with `Record` objects in this module, all field names from
-search services should be converted into a standard that is more familiar to Silverstripe developers.
+The `FieldService` class provides a method can be used to convert your index fields into a format that is more familiar
+to Silverstripe developers.
+
+```php
+$converted = FieldService::singleton()->getConvertedFieldName($fieldName);
+```
+
+I would recommend having a look at the example conversions in `FieldServiceTest` to understand how we transform
+different naming patterns.
+
+We should all try to following these standards when developing our service integrations:
 
 * PascalCase
 * Abbreviations like "ID", "IDs", "URL", etc, should be presented as "Id", "Ids", "Url", etc
@@ -17,15 +26,3 @@ equally impossible for this module to then guess whether you use that abbreviati
 
 The easiest, and most consistent way to solve this issue is to simply say that each portion of a field name that is
 separated by (eg) `-` or `_` is one word, and therefor treated as PascalCase, and not PascalCASE.
-
-Another reason for this standard is because PHP provides us with the `ucwords` function, and that's a really easy and
-consistent way to turn snake_case and kebab-case (which is a common field pattern for search services) into PascalCase.
-
-EG:
-
-```php
-// Convert snake_case to PascalCase
-str_replace('_', '', ucwords('snake_case', '_'));
-// Convert kebab-case to PascalCase
-str_replace('_', '', ucwords('kebab-case', '-'));
-```

--- a/docs/field-convensions.md
+++ b/docs/field-convensions.md
@@ -23,6 +23,3 @@ Why "Id" and not "ID"?
 Well.. ID is an easy one to predict because we know that Silverstripe uses that capitalised, but beyond that, it's
 impossible for this module to programmatically know what other abbreviations you might be using in your project, and
 equally impossible for this module to then guess whether you use that abbreviation fully capitalised or not.
-
-The easiest, and most consistent way to solve this issue is to simply say that each portion of a field name that is
-separated by (eg) `-` or `_` is one word, and therefor treated as PascalCase, and not PascalCASE.

--- a/src/Service/FieldService.php
+++ b/src/Service/FieldService.php
@@ -11,6 +11,15 @@ class FieldService
 
     public function getConvertedFieldName(string $fieldName): string
     {
+        // For camelCase and PascalCase we'll want to standardise them to snake_case (though, they will still have
+        // capitalisation, which is fine, as we'll handle this later)
+        $fieldNameSplit = preg_split('/(?<=[a-z])(?=[A-Z])/x', $fieldName);
+        // Glue the words back together with underscore as a separator
+        $fieldName = implode('_', $fieldNameSplit);
+        // Standardise everything to lowercase before we apply ucwords()
+        $fieldName = strtolower($fieldName);
+
+        // Format any snake_case field names
         $fieldName = str_replace('_', '', ucwords($fieldName, '_'));
 
         return str_replace('-', '', ucwords($fieldName, '-'));

--- a/src/Service/FieldService.php
+++ b/src/Service/FieldService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\Discoverer\Service;
+
+use SilverStripe\Core\Injector\Injectable;
+
+class FieldService
+{
+
+    use Injectable;
+
+    public function getConvertedFieldName(string $fieldName): string
+    {
+        $fieldName = str_replace('_', '', ucwords($fieldName, '_'));
+
+        return str_replace('-', '', ucwords($fieldName, '-'));
+    }
+
+}

--- a/tests/Service/FieldServiceTest.php
+++ b/tests/Service/FieldServiceTest.php
@@ -33,10 +33,15 @@ class FieldServiceTest extends SapphireTest
             ['Record-Id', 'RecordId'],
             ['recordId', 'RecordId'],
             ['RecordId', 'RecordId'],
+            ['RecordID', 'RecordId'],
+            ['recordID', 'RecordId'],
             ['tag_ids', 'TagIds'],
             ['tag-ids', 'TagIds'],
             ['tagIds', 'TagIds'],
             ['TagIds', 'TagIds'],
+            ['TagIDs', 'TagIds'],
+            ['tagIDs', 'TagIds'],
+            ['IDs', 'Ids'],
         ];
     }
 

--- a/tests/Service/FieldServiceTest.php
+++ b/tests/Service/FieldServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SilverStripe\Discoverer\Tests\Service;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Discoverer\Service\FieldService;
+
+class FieldServiceTest extends SapphireTest
+{
+
+    /**
+     * @dataProvider provideFieldNames
+     */
+    public function testGetConvertedFieldName(string $fieldName, string $expectedFieldName): void
+    {
+        $this->assertEquals(FieldService::singleton()->getConvertedFieldName($fieldName), $expectedFieldName);
+    }
+
+    public function provideFieldNames(): array
+    {
+        return [
+            ['title', 'Title'],
+            ['Title', 'Title'],
+            ['elemental_area', 'ElementalArea'],
+            ['Elemental_Area', 'ElementalArea'],
+            ['elemental-area', 'ElementalArea'],
+            ['Elemental-Area', 'ElementalArea'],
+            ['elementalArea', 'ElementalArea'],
+            ['ElementalArea', 'ElementalArea'],
+            ['record_id', 'RecordId'],
+            ['Record_Id', 'RecordId'],
+            ['record-id', 'RecordId'],
+            ['Record-Id', 'RecordId'],
+            ['recordId', 'RecordId'],
+            ['RecordId', 'RecordId'],
+            ['tag_ids', 'TagIds'],
+            ['tag-ids', 'TagIds'],
+            ['tagIds', 'TagIds'],
+            ['TagIds', 'TagIds'],
+        ];
+    }
+
+}


### PR DESCRIPTION
This previously lived in the plugin modules, but I felt that it probably could (and should) live in the base module, so that everyone is working to the same set of rules.

Examples.

* `title` = `Title`
* `term_ids` = `TermIds`
* `elemental-area` = `ElementalArea`
* `PageURL` = `PageUrl`
* `IDs` = `Ids`