### PR TITLE
Update filter value requirements for falsy values

### DIFF
--- a/src/Query/Filter/Criteria.php
+++ b/src/Query/Filter/Criteria.php
@@ -100,10 +100,6 @@ class Criteria implements Clause
             return $this;
         }
 
-        if (!isset($value) || $value === null) {
-            throw new Exception('mixed $value and string $comparison expected for filter()');
-        }
-
         if (!$comparison) {
             throw new Exception('string $comparison expected for filter()');
         }

--- a/src/Query/Filter/Criteria.php
+++ b/src/Query/Filter/Criteria.php
@@ -100,6 +100,11 @@ class Criteria implements Clause
             return $this;
         }
 
+        // Only NULL_COMPARISONS support a $value of null. All other falsy values are allowed
+        if ($value === null && !in_array($comparison, Criterion::NULL_COMPARISONS, true)) {
+            throw new Exception('mixed $value of null is not supported outside of NULL_COMPARISON filters');
+        }
+
         if (!$comparison) {
             throw new Exception('string $comparison expected for filter()');
         }

--- a/src/Query/Filter/Criteria.php
+++ b/src/Query/Filter/Criteria.php
@@ -100,7 +100,7 @@ class Criteria implements Clause
             return $this;
         }
 
-        if (!$value) {
+        if (!isset($value) || $value === null) {
             throw new Exception('mixed $value and string $comparison expected for filter()');
         }
 

--- a/src/Query/Filter/Criterion.php
+++ b/src/Query/Filter/Criterion.php
@@ -42,6 +42,11 @@ class Criterion implements Clause
         self::RANGE,
     ];
 
+    public const NULL_COMPARISONS = [
+        self::IS_NULL,
+        self::IS_NOT_NULL,
+    ];
+
     private ?CriterionAdaptor $adaptor = null;
 
     private static array $dependencies = [

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -204,7 +204,7 @@ class QueryTest extends SapphireTest
         $query = Query::create();
         $criterionOne = Criterion::create('field1', 'value1', Criterion::EQUAL);
         $criterionTwo = Criterion::create('field2', 'value2', Criterion::EQUAL);
-        $criterionThree = Criterion::create('field3', null, Criterion::NOT_EQUAL);
+        $criterionThree = Criterion::create('field3', '', Criterion::NOT_EQUAL);
         $criterionFour = Criterion::create('field4', 0, Criterion::NOT_EQUAL);
 
         $query->filter($criterionOne);
@@ -232,7 +232,7 @@ class QueryTest extends SapphireTest
         $this->assertEquals('value2', $criterionTwo->getValue());
         $this->assertEquals(Criterion::EQUAL, $criterionTwo->getComparison());
         $this->assertEquals('field3', $criterionThree->getTarget());
-        $this->assertNull($criterionThree->getValue());
+        $this->assertEquals('', $criterionThree->getValue());
         $this->assertEquals(Criterion::NOT_EQUAL, $criterionThree->getComparison());
         $this->assertEquals('field4', $criterionFour->getTarget());
         $this->assertEquals(0, $criterionFour->getValue());
@@ -270,7 +270,7 @@ class QueryTest extends SapphireTest
         $query->filterAny([
             $criterion,
             ['field2', 'value2', Criterion::EQUAL],
-            ['field3', null, Criterion::NOT_EQUAL],
+            ['field3', '', Criterion::NOT_EQUAL],
             ['field4', 0, Criterion::NOT_EQUAL],
         ]);
 
@@ -303,11 +303,20 @@ class QueryTest extends SapphireTest
         $this->assertEquals('value2', $criterionTwo->getValue());
         $this->assertEquals(Criterion::EQUAL, $criterionTwo->getComparison());
         $this->assertEquals('field3', $criterionThree->getTarget());
-        $this->assertNull($criterionThree->getValue());
+        $this->assertEquals('', $criterionThree->getValue());
         $this->assertEquals(Criterion::NOT_EQUAL, $criterionThree->getComparison());
         $this->assertEquals('field4', $criterionFour->getTarget());
         $this->assertEquals(0, $criterionFour->getValue());
         $this->assertEquals(Criterion::NOT_EQUAL, $criterionFour->getComparison());
+    }
+
+    public function testFilterNoValue(): void
+    {
+        $this->expectExceptionMessage('mixed $value of null is not supported outside of NULL_COMPARISON filters');
+
+        $query = Query::create();
+        // Should throw our exception
+        $query->filter('field1');
     }
 
     public function testFilterNoComparison(): void

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -204,18 +204,26 @@ class QueryTest extends SapphireTest
         $query = Query::create();
         $criterionOne = Criterion::create('field1', 'value1', Criterion::EQUAL);
         $criterionTwo = Criterion::create('field2', 'value2', Criterion::EQUAL);
+        $criterionThree = Criterion::create('field3', null, Criterion::NOT_EQUAL);
+        $criterionFour = Criterion::create('field4', 0, Criterion::NOT_EQUAL);
 
         $query->filter($criterionOne);
         $query->filter($criterionTwo);
+        $query->filter($criterionThree);
+        $query->filter($criterionFour);
 
         $clauses = $query->getFilter()->getClauses();
 
-        $this->assertCount(2, $clauses);
+        $this->assertCount(4, $clauses);
 
         /** @var Criterion $criterionOne */
         $criterionOne = array_shift($clauses);
         /** @var Criterion $criterionTwo */
         $criterionTwo = array_shift($clauses);
+        /** @var Criterion $criterionThree */
+        $criterionThree = array_shift($clauses);
+        /** @var Criterion $criterionFour */
+        $criterionFour = array_shift($clauses);
 
         $this->assertEquals('field1', $criterionOne->getTarget());
         $this->assertEquals('value1', $criterionOne->getValue());
@@ -223,6 +231,12 @@ class QueryTest extends SapphireTest
         $this->assertEquals('field2', $criterionTwo->getTarget());
         $this->assertEquals('value2', $criterionTwo->getValue());
         $this->assertEquals(Criterion::EQUAL, $criterionTwo->getComparison());
+        $this->assertEquals('field3', $criterionThree->getTarget());
+        $this->assertNull($criterionThree->getValue());
+        $this->assertEquals(Criterion::NOT_EQUAL, $criterionThree->getComparison());
+        $this->assertEquals('field4', $criterionFour->getTarget());
+        $this->assertEquals(0, $criterionFour->getValue());
+        $this->assertEquals(Criterion::NOT_EQUAL, $criterionFour->getComparison());
     }
 
     public function testFilterWithTarget(): void
@@ -256,7 +270,8 @@ class QueryTest extends SapphireTest
         $query->filterAny([
             $criterion,
             ['field2', 'value2', Criterion::EQUAL],
-            ['field3', 'value3', Criterion::EQUAL],
+            ['field3', null, Criterion::NOT_EQUAL],
+            ['field4', 0, Criterion::NOT_EQUAL],
         ]);
 
         $clauses = $query->getFilter()->getClauses();
@@ -278,6 +293,8 @@ class QueryTest extends SapphireTest
         $criterionTwo = array_shift($clauses);
         /** @var Criterion $criterionThree */
         $criterionThree = array_shift($clauses);
+        /** @var Criterion $criterionFour */
+        $criterionFour = array_shift($clauses);
 
         $this->assertEquals('field1', $criterionOne->getTarget());
         $this->assertEquals('value1', $criterionOne->getValue());
@@ -286,17 +303,11 @@ class QueryTest extends SapphireTest
         $this->assertEquals('value2', $criterionTwo->getValue());
         $this->assertEquals(Criterion::EQUAL, $criterionTwo->getComparison());
         $this->assertEquals('field3', $criterionThree->getTarget());
-        $this->assertEquals('value3', $criterionThree->getValue());
-        $this->assertEquals(Criterion::EQUAL, $criterionThree->getComparison());
-    }
-
-    public function testFilterNoValue(): void
-    {
-        $this->expectExceptionMessage('mixed $value and string $comparison expected for filter()');
-
-        $query = Query::create();
-        // Should throw our exception
-        $query->filter('field1');
+        $this->assertNull($criterionThree->getValue());
+        $this->assertEquals(Criterion::NOT_EQUAL, $criterionThree->getComparison());
+        $this->assertEquals('field4', $criterionFour->getTarget());
+        $this->assertEquals(0, $criterionFour->getValue());
+        $this->assertEquals(Criterion::NOT_EQUAL, $criterionFour->getComparison());
     }
 
     public function testFilterNoComparison(): void


### PR DESCRIPTION
It may be an edge case, but it could be useful to be able to filter with a value of 0 (either string or int).
For instance, if subsite_id is used as a field to filter the results rather than having separate indices, to get the main sites results we would need to filter by 0, which the current code doesn't allow since it evaluates !$value would be true.