### PR TITLE
Fix for facet value types. Add support for facet value name

### DIFF
--- a/src/Service/Results/FacetData.php
+++ b/src/Service/Results/FacetData.php
@@ -13,7 +13,9 @@ class FacetData extends ViewableData
 
     private string|int|float $to;
 
-    private string $value;
+    private string $name;
+
+    private string|int|float $value;
 
     public function getCount(): int
     {
@@ -51,12 +53,24 @@ class FacetData extends ViewableData
         return $this;
     }
 
-    public function getValue(): string
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getValue(): string|int|float
     {
         return $this->value;
     }
 
-    public function setValue(string $value): self
+    public function setValue(string|int|float $value): self
     {
         $this->value = $value;
 


### PR DESCRIPTION
## Values

Facet values can be `string`, `int`, `float` (potentially others as well, but I'd be happy to add those when we come across them).

## Data names

Pieces of facet data can individual have their own names assigned, and we didn't currently have the ability to set these to the result object.