### PR TITLE
AOS-100: Mitigating XSS when displaying the query term in the search templates

### DIFF
--- a/docs/detailed-result-handling.md
+++ b/docs/detailed-result-handling.md
@@ -20,9 +20,12 @@ simple methods available that you can access anywhere.
 * `isSuccess()`: Simply states whether or not the search was a success, or error.
 * `getRecords()`: A `PaginatedList` of `Record` objects that were returned by the search service based on your `Query`.
 * `getFacets`: An `ArrayList` of `Facet` objects that were returned by the search service based on your `Query`.
+* `getQuery()`: The `Query` object, including the user entered search term.
 
-The `Results` class is also a `ViewableData` object, so these methods can be access in your template with `$isSuccess`,
-`$Records`, and `$Facets`.
+The `Results` class is also a `ViewableData` object, so these methods can be accessed in your template with `$isSuccess`,
+`$Records`, `$Facets`, and `$Query`. 
+
+**Note:** When outputting `$Query` to a template a sanitised version of the user entered search term is displayed.
 
 ## `Record` class
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Discoverer\Query;
 
 use Exception;
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Query\Facet\Facet;
 use SilverStripe\Discoverer\Query\Facet\FacetCollection;
@@ -271,7 +272,9 @@ class Query
 
     public function forTemplate(): string
     {
-        return $this->queryString;
+        // the query string potentially contains raw user input and should be sanitised for
+        // rendering to the template
+        return Convert::raw2xml($this->queryString);
     }
 
     /**

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -397,8 +397,17 @@ class QueryTest extends SapphireTest
         $this->assertEquals($expected, $query->getTags());
     }
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Injector::inst()->registerService(new MockCriteriaAdaptor(), CriteriaAdaptor::class);
+        Injector::inst()->registerService(new MockCriterionAdaptor(), CriterionAdaptor::class);
+        Injector::inst()->registerService(new MockFacetAdaptor(), FacetAdaptor::class);
+    }
+
     /**
-     * Data provider for testing search terms and ensuring sanitization of user input to mitigate XSS issues.
+     * Data provider for testing search terms and ensuring escaping of user input to mitigate XSS issues.
      *
      * @return array[]
      */
@@ -420,15 +429,6 @@ class QueryTest extends SapphireTest
                 'expected' => '&lt;IMG height=100 width=100 onmouseover=alert(&#039;test&#039;)&gt;',
             ],
         ];
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Injector::inst()->registerService(new MockCriteriaAdaptor(), CriteriaAdaptor::class);
-        Injector::inst()->registerService(new MockCriterionAdaptor(), CriterionAdaptor::class);
-        Injector::inst()->registerService(new MockFacetAdaptor(), FacetAdaptor::class);
     }
 
 }

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -14,7 +14,6 @@ use SilverStripe\Discoverer\Query\Query;
 use SilverStripe\Discoverer\Tests\Query\Facet\MockFacetAdaptor;
 use SilverStripe\Discoverer\Tests\Query\Filter\MockCriteriaAdaptor;
 use SilverStripe\Discoverer\Tests\Query\Filter\MockCriterionAdaptor;
-use SilverStripe\ORM\FieldType\DBHTMLText;
 
 class QueryTest extends SapphireTest
 {
@@ -407,16 +406,18 @@ class QueryTest extends SapphireTest
     {
         return [
             [
-                'term' => '%26%23123%3B%26%23123%3B%27tenablewas_VuSleDMm7Rcj%27%2B4419%2A5502%26%23125%3B%26%23125%3B',
-                'expected' => '%26%23123%3B%26%23123%3B%27tenablewas_VuSleDMm7Rcj%27%2B4419%2A5502%26%23125%3B%26%23125%3B'
+                'term' => '%26%23123%3B%26%23123%3B%27tenablewas_'
+                    . 'VuSleDMm7Rcj%27%2B4419%2A5502%26%23125%3B%26%23125%3B',
+                'expected' => '%26%23123%3B%26%23123%3B%27tenablewas_'
+                    . 'VuSleDMm7Rcj%27%2B4419%2A5502%26%23125%3B%26%23125%3B',
             ],
             [
                 'term' => '<h1>Test</h1>',
-                'expected' => '&lt;h1&gt;Test&lt;/h1&gt;'
+                'expected' => '&lt;h1&gt;Test&lt;/h1&gt;',
             ],
             [
                 'term' => '<IMG height=100 width=100 onmouseover=alert(\'test\')>',
-                'expected' => '&lt;IMG height=100 width=100 onmouseover=alert(&#039;test&#039;)&gt;'
+                'expected' => '&lt;IMG height=100 width=100 onmouseover=alert(&#039;test&#039;)&gt;',
             ],
         ];
     }


### PR DESCRIPTION
# Jira ticket
[AOS-100 XSS possible on default sdk setup](https://silverstripe.atlassian.net/browse/AOS-100)

# Description
A common pattern for a search results page is to display the original query term within the results summary text.
For example, `Displaying 1 - 10 results of 20 for "health"`

So we could set this up by passing the query object into the Summary.ss template and changing it to ...

````
<p class="discoverer-results__summary"><%t SilverStripe\Discoverer\Includes\Summary.Results 'Displaying {first} - {last} results of {total} for "{query}"' first=$FirstItem last=$LastItem total=$TotalItems query=$query %></p>
````

Although this perhaps this is an implementation issue rather than a module issue, and there are alternatives for the developer to ensure output is sanitised, this would seem the most convenient way of including the search term in the template. Currently when doing this there is an XSS issue where user input is output directly to the template.

For example,
`<h1 style='color:red'>Test</h1>` as search term: 
<img width="477" height="198" alt="Screenshot 2025-08-19 at 9 01 04 AM" src="https://github.com/user-attachments/assets/ac49c8a1-d50f-4084-aa80-1bb141bec8b6" />

`<IMG height=100 width=100 onmouseover=alert('test')>` as the search term:
<img width="939" height="242" alt="Screenshot 2025-08-19 at 9 03 22 AM" src="https://github.com/user-attachments/assets/2e863ad8-3b25-4e9c-b7c9-f5e9a15e3e30" />

# Change
The `forTemplate` function on the Query class returns the raw search query. We should probably sanitise this and escape any potentially harmful characters before it is displayed in the template.

With fix:

<img width="757" height="143" alt="Screenshot 2025-08-19 at 9 08 32 AM" src="https://github.com/user-attachments/assets/b43f7ff0-831b-4634-8a37-9d0cfa5adba8" />



