### PR TITLE
AOS-100: Add documentation regards the Query class and sanitising the…

### DIFF
--- a/docs/detailed-result-handling.md
+++ b/docs/detailed-result-handling.md
@@ -20,9 +20,17 @@ simple methods available that you can access anywhere.
 * `isSuccess()`: Simply states whether or not the search was a success, or error.
 * `getRecords()`: A `PaginatedList` of `Record` objects that were returned by the search service based on your `Query`.
 * `getFacets`: An `ArrayList` of `Facet` objects that were returned by the search service based on your `Query`.
+* `getQuery`": The `Query` object
 
 The `Results` class is also a `ViewableData` object, so these methods can be access in your template with `$isSuccess`,
-`$Records`, and `$Facets`.
+`$Records`, `$Facets`, and `$Query`.
+
+## `Query` class
+The `Query` class provides the original query that was used for matching results. This is available should you wish
+to include `Showing results for "test"` or similar text on your results page.
+
+**Important:** When including `$Query` in the template it should be noted that this assumes the query string is
+safe and that the implementation has sanitised the user input to mitigate against cross-site scripting (xss) attacks.
 
 ## `Record` class
 


### PR DESCRIPTION
# Jira ticket
[AOS-100 XSS possible on default sdk setup](https://silverstripe.atlassian.net/browse/AOS-100)

# Description
A common pattern for a search results page is to display the original query term within the results summary text.
For example, `Displaying 1 - 10 results of 20 for "health"`

So we could set this up by passing the query object into the Summary.ss template and changing it to ...

````
<p class="discoverer-results__summary"><%t SilverStripe\Discoverer\Includes\Summary.Results 'Displaying {first} - {last} results of {total} for "{query}"' first=$FirstItem last=$LastItem total=$TotalItems query=$query %></p>
````

Although this perhaps this is an implementation issue rather than a module issue, and there are alternatives for the developer to ensure output is sanitised, this would seem the most convenient way of including the search term in the template. Currently when doing this there is an XSS issue where user input is output directly to the template.

For example,
`<h1 style='color:red'>Test</h1>` as search term: 
<img width="477" height="198" alt="Screenshot 2025-08-19 at 9 01 04 AM" src="https://github.com/user-attachments/assets/ac49c8a1-d50f-4084-aa80-1bb141bec8b6" />

`<IMG height=100 width=100 onmouseover=alert('test')>` as the search term:
<img width="939" height="242" alt="Screenshot 2025-08-19 at 9 03 22 AM" src="https://github.com/user-attachments/assets/2e863ad8-3b25-4e9c-b7c9-f5e9a15e3e30" />

# Documentation changes
I had originally considered updating the `Query` class so that the `forTemplate` function returns a sanitised version of the query string. However, we don't really know if the string has already been sanitised. A number of current search implementations do this sanitisation elsewhere.  

I've added documentation to highlight importance of sanitising the query string within the search implementation, since the Query class assumes that it is safe to include in the template.
