### PR TITLE
AOS-100: Update docs for sanitisation

### DIFF
--- a/docs/detailed-result-handling.md
+++ b/docs/detailed-result-handling.md
@@ -20,7 +20,7 @@ simple methods available that you can access anywhere.
 * `isSuccess()`: Simply states whether or not the search was a success, or error.
 * `getRecords()`: A `PaginatedList` of `Record` objects that were returned by the search service based on your `Query`.
 * `getFacets`: An `ArrayList` of `Facet` objects that were returned by the search service based on your `Query`.
-* `getQuery`": The `Query` object containing the user entered search term. See the [Query class](#query-class) section below for safe handling of user input.
+* `getQuery`: The `Query` object containing the user entered search term. See the [Query class](#query-class) section below for safe handling of user input.
 
 The `Results` class is also a `ViewableData` object, so these methods can be access in your template with `$isSuccess`,
 `$Records`, and `$Facets`.


### PR DESCRIPTION
# Jira ticket
[https://silverstripe.atlassian.net/browse/AOS-100](https://silverstripe.atlassian.net/browse/AOS-100)

# Description
I've previously updated the documentation to include `$Query` for adding to the template. However, since it might not be a sanitised string (see https://github.com/silverstripeltd/silverstripe-discoverer-search-ui/pull/17) we perhaps shouldn't suggest adding $Query directly and just say it should be sanitised/escaped if adding to the template.